### PR TITLE
Add monitoring and metrics visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,42 @@
 This repository contains the test infrastructure configuration of the Nanopublication ecosystem.
 
+### Main charts
+
 The `nanopub` directory contains separate subcharts for Query ( as `query`) and Registry ( as `registry`) instances. They can be deployed separately or as a part of the larger `nanopub` chart. If deployed as a part of the `nanopub` chart, both Query and Registry instances will be connected by default and can be configured to be deployed together on a separate node (through setting `global.nodeSelectorLabel` in the `nanopub/values.yaml` file). 
 
 `general-query-service.yaml` and `general-registry-service.yaml` specify overarching services that will connect to all Query instances and all Registry instances in the cluster regardless of the release. The services use the default Kubernetes load balancer of your distribution.  
 
+### Monitoring and visualization
+
+Aside from the main chart, the repository contains a setup for monitoring and visualization consisting of Prometheus (used to scrape the metrics from Query and Registry instances), Victoria Metrics (used for persistent storage of these metrics) and Grafana (used to visualize the scraped metrics). 
+
+To set it up, follow the instructions below.
+
+Start by installing Victoria Metrics with the options predefined by running:
+
+```
+helm repo add vm https://victoriametrics.github.io/helm-charts/
+helm install vms vm/victoria-metrics-single -f metrics/vm-values.yaml
+```
+
+By default, VM will run as a monolith, connect to the host machine on the node port `31333` and retain the data for 1 year. All of these options can be modified through changing the appropriate fields in `metrics/vm-values.yaml` and running
+
+`helm upgrade --install vms vm/victoria-metrics-single -f metrics/vm-values.yaml`.
+
+Then install Prometheus through:
+
+```
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm install prometheus prometheus-community/prometheus -f metrics/prometheus-values.yaml
+```
+
+This should cause Prometheus to connect automatically to the `/metrics` endpoints exposed by the Registry and Query instances located in the same cluster, as well as to the VM instance configured before. Prometheus server will be available on the host machine on node port `31165`.
+
+Finally, install Grafana with:
+
+```
+helm repo add grafana https://grafana.github.io/helm-charts
+helm install grafana grafana/grafana -f metrics/grafana-values.yaml
+```
+
+Grafana will automatically connect to the Prometheus and VM instances configured above. The dashboard will be exposed on the host machine on port `31430`. By default, authentication to the dashboard will be disabled.

--- a/monitoring/grafana-values.yaml
+++ b/monitoring/grafana-values.yaml
@@ -1,0 +1,27 @@
+service:
+  type: NodePort
+  nodePort: "31430"
+
+env:
+  GF_AUTH_ANONYMOUS_ENABLED: "true"
+  GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+  GF_AUTH_DISABLE_LOGIN_FORM: "true"
+  GF_AUTH_BASIC_ENABLED: "false"
+
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: VictoriaMetrics
+        type: prometheus
+        access: proxy
+        url: http://vms-victoria-metrics-single-server:8428
+        isDefault: true
+        version: 1
+
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus-server:80
+        isDefault: false
+        version: 1

--- a/monitoring/prometheus-values.yaml
+++ b/monitoring/prometheus-values.yaml
@@ -1,6 +1,11 @@
 server:
   service:
     type: NodePort
+    nodePort: "31165"
+
+      
+  remoteWrite:
+    - url: http://vms-victoria-metrics-single-server:8428/api/v1/write
 
 extraScrapeConfigs: |
   - job_name: 'registry-pods'
@@ -15,6 +20,10 @@ extraScrapeConfigs: |
       - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
         action: keep
         regex: registry
+        target_label: name
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+        target_label: component
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
         target_label: name
       - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
         target_label: instance
@@ -35,6 +44,10 @@ extraScrapeConfigs: |
       - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
         action: keep
         regex: query
+        target_label: name
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+        target_label: component
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
         target_label: name
       - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
         target_label: instance

--- a/monitoring/vm-values.yaml
+++ b/monitoring/vm-values.yaml
@@ -1,0 +1,6 @@
+server:
+  service:
+    type: NodePort
+    nodePort: "31333"
+  # specify for how long is data retained in the database
+  retentionPeriod: 1y

--- a/nanopub/charts/query/templates/_helpers.tpl
+++ b/nanopub/charts/query/templates/_helpers.tpl
@@ -97,7 +97,6 @@ Component application selector labels
 {{- define "application.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "query.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-query: {{ .Chart.Name }}
 app.kubernetes.io/component: application
 isMainInterface: "yes"
 tier: {{ .Values.application.tier }}

--- a/nanopub/charts/query/values.yaml
+++ b/nanopub/charts/query/values.yaml
@@ -1,4 +1,4 @@
-nameOverride: "new"
+nameOverride: ""
 
 fullnameOverride: ""
 

--- a/nanopub/charts/registry/templates/_helpers.tpl
+++ b/nanopub/charts/registry/templates/_helpers.tpl
@@ -149,7 +149,6 @@ Component db selector labels
 {{- define "db.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "registry.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-registry: {{ .Chart.Name }}
 app.kubernetes.io/component: db
 isMainInterface: "no"
 tier: {{ .Values.db.tier }}

--- a/prometheus-values.yaml
+++ b/prometheus-values.yaml
@@ -1,0 +1,44 @@
+server:
+  service:
+    type: NodePort
+
+extraScrapeConfigs: |
+  - job_name: 'registry-pods'
+    scrape_interval: 30s
+    kubernetes_sd_configs:
+      - role: pod
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+        action: keep
+        regex: application
+        target_label: component
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        action: keep
+        regex: registry
+        target_label: name
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+        target_label: instance
+      - source_labels: [__address__]
+        regex: (.+):\d+
+        target_label: __address__
+        replacement: $1:9293
+
+  - job_name: 'query-pods'
+    scrape_interval: 30s
+    kubernetes_sd_configs:
+      - role: pod
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+        action: keep
+        regex: application
+        target_label: component
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        action: keep
+        regex: query
+        target_label: name
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+        target_label: instance
+      - source_labels: [__address__]
+        regex: (.+):\d+
+        target_label: __address__
+        replacement: $1:9394


### PR DESCRIPTION
The PR introduces a simple setup for visualization and monitoring consisting of a Prometheus instance preconfigured to scrape all Query and Registry instances available in the cluster, a Victoria Metrics instance used to persist Prometheus metrics and a Grafana instance for visualization purposes. Prometheus and Grafana deployments are preconfigured to connect to the rest of the setup by default, and the Grafana deployment runs with disabled authentication for ease of use.

The setup has been tested locally on a cluster with 4 Query and Registry instances. Here are the active Prometheus targets:
![Screenshot from 2025-06-22 20-35-52](https://github.com/user-attachments/assets/4867e248-f7b8-423c-8bbf-14abcfc1a23d)
And the process of nanopub loading shown in Grafana:
![Screenshot from 2025-06-22 21-32-31](https://github.com/user-attachments/assets/e15d54bc-a18a-4a5a-84fc-d2f874bde1cf)
Aside from that, minor issues such as unnecessary labels and unnecessary name in the original charts have been fixed.