### PR TITLE
Added retractions, multiple pubkeys, active accounts tracking functionality

### DIFF
--- a/nanopub_generator/config.yaml
+++ b/nanopub_generator/config.yaml
@@ -89,3 +89,8 @@ nanopubs:
     # Number of nanopubs IRIs to keep in cache, for potential commenting on / updating.
     # Old nanopubs will be removed in random order from the cache.
     recent_count: 100
+
+  retract:
+    # Weight of the nanopub type in the distribution. The weights are relative and don't need to sum to 1.
+    weight: 0.05
+    recent_count: 100

--- a/nanopub_generator/nanopub_generator/constants.py
+++ b/nanopub_generator/nanopub_generator/constants.py
@@ -1,9 +1,11 @@
-NP_TYPE_PLAIN = 'plain_assertion'
-NP_TYPE_COMMENT = 'comment'
-NP_TYPE_UPDATE = 'update_assertion'
+NP_TYPE_PLAIN = "plain_assertion"
+NP_TYPE_COMMENT = "comment"
+NP_TYPE_UPDATE = "update_assertion"
+NP_TYPE_RETRACT = "retract"
 
 NP_TYPES = [
     NP_TYPE_PLAIN,
     NP_TYPE_COMMENT,
     NP_TYPE_UPDATE,
+    NP_TYPE_RETRACT,
 ]

--- a/nanopub_generator/nanopub_generator/data_gen.py
+++ b/nanopub_generator/nanopub_generator/data_gen.py
@@ -73,11 +73,11 @@ class NanopubFaker(Faker):
         """Generate an rng ORCID URL."""
         return f"https://orcid.org/{self.orcid()}"
 
-    def np_profile(self) -> np.Profile:
+    def np_profile(self, orcid_id: str = None, name: str = None) -> np.Profile:
         """Generate an rng nanopub profile."""
         return np.Profile(
-            orcid_id=self.orcid_url(),
-            name=self.name(),
+            orcid_id=self.orcid_url() if orcid_id is None else orcid_id,
+            name=self.name() if name is None else name,
         )
 
     def np_base(self, assertion: rdf.Graph, conf: np.NanopubConf, np_type: rdf.URIRef) -> np.Nanopub:
@@ -178,6 +178,18 @@ class NanopubFaker(Faker):
             rdf.Literal(self.paragraph(nb_sentences=3), lang='en')
         ))
         return self.np_base(a, conf, TEST.Comment)
+        
+    def np_retract(self, conf: np.NanopubConf, to_retract: np.Nanopub) -> np.Nanopub:
+        """Create a retraction for a given nanopub."""
+        a = rdf.Graph()
+        a.add(
+            (
+                rdf.URIRef(conf.profile.orcid_id),
+                NPX.retracts,
+                rdf.URIRef(to_retract.source_uri),
+            )
+        )
+        return self.np_base(a, conf, NPX.retracts)
 
     def np_update(self, conf: np.NanopubConf, supersede: np.Nanopub) -> np.Nanopub:
         """Generate a nanopub updating a different nanopub or any other IRI."""

--- a/nanopub_generator/nanopub_generator/distribution.py
+++ b/nanopub_generator/nanopub_generator/distribution.py
@@ -3,27 +3,30 @@ from random import Random
 
 class ParetoDist:
     """https://en.wikipedia.org/wiki/Pareto_distribution#Generating_bounded_Pareto_random_variables"""
-    def __init__(self, rng: Random, minimum: int, maximum: int):
+
+    def __init__(self, rng: Random, minimum: int, maximum: int, alpha: float = 0.5):
         self.rng = rng
-        self.alpha = 0.5
+        self.alpha = alpha
         l = minimum + 1  # lower bound
         h = maximum + 1  # upper bound
-        self.la = l ** self.alpha
-        self.ha = h ** self.alpha
-        self.exp = (-1 / self.alpha)
+        self.la = l**self.alpha
+        self.ha = h**self.alpha
+        self.exp = -1 / self.alpha
         self.laha = self.la * self.ha
 
     def sample(self):
         """Sample an item from the data based on a power-law distribution."""
         u = self.rng.random()
         x1 = -(u * self.ha - u * self.la - self.ha) / self.laha
-        x2 = x1 ** self.exp
+        x2 = x1**self.exp
         return int(round(x2 - 1, 0))
+
 
 class ParetoDistList(ParetoDist):
     """https://en.wikipedia.org/wiki/Pareto_distribution#Generating_bounded_Pareto_random_variables"""
-    def __init__(self, data: list, rng: Random):
-        super().__init__(rng, 0, len(data) - 1)
+
+    def __init__(self, data: list, rng: Random, alpha: float = 0.5):
+        super().__init__(rng, 0, len(data) - 1, alpha)
         self.data = data
 
     def sample_item(self):

--- a/nanopub_generator/nanopub_generator/generator.py
+++ b/nanopub_generator/nanopub_generator/generator.py
@@ -1,3 +1,4 @@
+from collections import deque
 from random import Random
 
 from nanopub import *
@@ -5,39 +6,62 @@ from nanopub import *
 from constants import *
 from data_gen import NanopubFaker
 from recent_nanopubs import RecentNanopubs
+from distribution import ParetoDistList, ParetoDist
 
 
 class NanopubGenerator:
     def __init__(self, config: dict, args):
         self.dry_run = args.dry_run
         self.config = config
-        self.rng = Random(config['generator']['seed'])
+        self.rng = Random(config["generator"]["seed"])
         self.recent_nps = RecentNanopubs(config, self.rng)
         self.fake = NanopubFaker(config, self.rng, self.recent_nps)
+        self.counter_nanopubs = 0
+        self.registry_url = args.registry_url
         # Create users
-        self.np_config_map = {
-            profile.orcid_id: NanopubConf(
-                use_server=args.registry_url,
-                profile=profile,
-                add_prov_generated_time=True,
-                add_pubinfo_generated_time=True,
-                attribute_publication_to_profile=True,
-                attribute_assertion_to_profile=True,
+        self.pareto_pubkeys = ParetoDist(self.rng, 1, 50, 5.5)
+        self.np_accounts_map = {
+            profile.orcid_id: deque(
+                [
+                    NanopubConf(
+                        use_server=self.registry_url,
+                        profile=profile,
+                        add_prov_generated_time=True,
+                        add_pubinfo_generated_time=True,
+                        attribute_publication_to_profile=True,
+                        attribute_assertion_to_profile=True,
+                    )
+                ],
+                maxlen=self.pareto_pubkeys.sample(),
             )
-            for _ in range(config['users']['count'])
+            for _ in range(config["generator"]["users"]["count"])
             for profile in [self.fake.np_profile()]
         }
-        self.np_config_list = list(self.np_config_map.values())
+        self.update_accounts_details()
+        self.accounts_to_complete = [
+            k for k, v in self.np_accounts_map.items() if len(v) < v.maxlen
+        ]
+
+    def update_accounts_details(self):
+        self.np_accounts_list = ParetoDistList(
+            list(self.np_accounts_map.values()),
+            self.rng,
+            1,
+        )
+        self.rev_np_accounts_list = ParetoDistList(
+            list(self.np_accounts_map.keys())[::-1],
+            self.rng,
+            1,
+        )
 
     def choose_nanopub_type(self) -> str:
         """Choose a nanopub type based on the configured weights."""
         return self.rng.choices(
             population=NP_TYPES,
             weights=[
-                self.config['nanopubs'][np_type]['weight']
-                for np_type in NP_TYPES
+                self.config["nanopubs"][np_type]["weight"] for np_type in NP_TYPES
             ],
-            k=1
+            k=1,
         )[0]
 
     def publish_nanopub_safe(self) -> None:
@@ -46,35 +70,121 @@ class NanopubGenerator:
         except Exception as e:
             print(f"Error publishing nanopub: {e}")
 
+    def add_pubkey(self):
+        if (len(self.accounts_to_complete)) > 0:
+            account_orcid = self.rng.choice(self.accounts_to_complete)
+            self.np_accounts_map[account_orcid].append(
+                NanopubConf(
+                    use_server=self.registry_url,
+                    profile=self.fake.np_profile(
+                        account_orcid,
+                        self.np_accounts_map[account_orcid][0].profile.name,
+                    ),
+                    add_prov_generated_time=True,
+                    add_pubinfo_generated_time=True,
+                    attribute_publication_to_profile=True,
+                    attribute_assertion_to_profile=True,
+                )
+            )
+            # If the account's profiles are filled, remove it from the list
+            if (
+                len(self.np_accounts_map[account_orcid])
+                == self.np_accounts_map[account_orcid].maxlen
+            ):
+                self.accounts_to_complete.remove(account_orcid)
+        else:
+            print("No accounts to add pubkeys to.")
+
+    def remove_account(self):
+        account_to_remove = self.rev_np_accounts_list.sample_item()
+        self.np_accounts_map.pop(account_to_remove)
+        if account_to_remove in self.accounts_to_complete:
+            self.accounts_to_complete.remove(account_to_remove)
+        self.update_accounts_details()
+
+    def add_account(self):
+        profile = self.fake.np_profile()
+        account = deque(
+            [
+                NanopubConf(
+                    use_server=self.registry_url,
+                    profile=profile,
+                    add_prov_generated_time=True,
+                    add_pubinfo_generated_time=True,
+                    attribute_publication_to_profile=True,
+                    attribute_assertion_to_profile=True,
+                )
+            ],
+            maxlen=self.pareto_pubkeys.sample(),
+        )
+        self.np_accounts_map.update({profile.orcid_id: account})
+        self.update_accounts_details()
+        if account.maxlen > 1:
+            self.accounts_to_complete.append(profile.orcid_id)
+
+    def find_nanopub_posting_config(self, np_to_examine: nanopub.Nanopub):
+        posting_account = self.np_accounts_map.get(np_to_examine.profile.orcid_id)
+        if posting_account is None:
+            raise Exception(
+                "Posting account for nanopub was not found in the list of active accounts."
+            )
+        return np_to_examine.conf
+
     def publish_nanopub(self) -> None:
-        # TODO: use ParetoDistList to sample the user
-        # TODO: many pubkeys per user
-        np_conf = self.rng.choice(self.np_config_list)
+        np_account = self.np_accounts_list.sample_item()
         np_type = self.choose_nanopub_type()
+        if len(np_account) == 1:
+            np_config = np_account[0]
+        else:
+            select_pubkey = ParetoDist(self.rng, 0, len(np_account) - 1, 1)
+            np_config = np_account[select_pubkey.sample()]
+
         if np_type == NP_TYPE_PLAIN:
-            pub = self.fake.np_about_paper(np_conf)
+            pub = self.fake.np_about_paper(np_config)
         elif np_type == NP_TYPE_COMMENT:
             recent_pub = self.recent_nps.get_recent_nanopub()
             if recent_pub is None:
                 print("No recent nanopub to comment on.")
                 return
-            pub = self.fake.np_comment(np_conf, recent_pub.source_uri)
+            pub = self.fake.np_comment(np_config, recent_pub.source_uri)
         elif np_type == NP_TYPE_UPDATE:
             recent_pub = self.recent_nps.get_recent_nanopub(NP_TYPE_PLAIN)
             if recent_pub is None:
                 print("No recent plain nanopub to update.")
                 return
-            # Find the original configuration for the recent nanopub
-            recent_pub_conf = self.np_config_map.get(recent_pub.profile.orcid_id)
-            pub = self.fake.np_update(recent_pub_conf, recent_pub)
+            poster_config = self.find_nanopub_posting_config(recent_pub)
+            pub = self.fake.np_update(poster_config, recent_pub)
+        elif np_type == NP_TYPE_RETRACT:
+            # Retract random np (but not another retraction)
+            nt_type_to_retract = self.rng.choice(
+                [NP_TYPE_PLAIN, NP_TYPE_UPDATE, NP_TYPE_COMMENT]
+            )
+            recent_pub = self.recent_nps.get_recent_nanopub(nt_type_to_retract)
+            if recent_pub is None:
+                print(
+                    f"Failed to find a recent publication of type {nt_type_to_retract} to retract"
+                )
+                return
+            # Find the original configuration for the recent nanopub to reuse
+            poster_config = self.find_nanopub_posting_config(recent_pub)
+            pub = self.fake.np_retract(poster_config, recent_pub)
+            self.recent_nps.remove_retracted(recent_pub)
         else:
             raise NotImplementedError(f"Unsupported nanopub type: {np_type}")
 
         pub.sign()
         self.recent_nps.update_recent_nanopubs(pub, np_type)
         if self.dry_run:
-            print(f"\n---- Dry run: Would publish nanopub: ----\n")
+            print("\n---- Dry run: Would publish nanopub: ----\n")
             print(pub)
         else:
             pub.publish()
             print(f"Published nanopub: {pub.source_uri}")
+        self.counter_nanopubs += 1
+        if self.counter_nanopubs % 100 == 0:
+            print("Adding a pubkey...")
+            self.add_pubkey()
+        if self.counter_nanopubs % 1000 == 0:
+            print("Removing an old and adding a new account...")
+            self.remove_account()
+            self.add_account()

--- a/nanopub_generator/nanopub_generator/recent_nanopubs.py
+++ b/nanopub_generator/nanopub_generator/recent_nanopubs.py
@@ -4,6 +4,7 @@ from nanopub import *
 
 from constants import *
 
+
 class RecentNanopubs:
     def __init__(self, config: dict, rng: Random):
         self.config = config
@@ -14,7 +15,7 @@ class RecentNanopubs:
         """Update the list of recent nanopubs."""
         np_list = self.recent_nanopubs[np_type]
         np_list.append(nanopub)
-        if len(np_list) > self.config['nanopubs'][np_type]['recent_count']:
+        if len(np_list) > self.config["nanopubs"][np_type]["recent_count"]:
             np_list.pop(self.rng.randint(0, len(np_list)))
 
     def get_recent_nanopub(self, np_type: str = None) -> Nanopub | None:
@@ -27,4 +28,13 @@ class RecentNanopubs:
         for np_list in lists:
             if len(np_list) > 0:
                 return self.rng.choice(np_list)
+        return None
+
+    def remove_retracted(self, retracted_pub) -> None:
+        """Remove the retracted nanopublication from all lists."""
+        for lst in self.recent_nanopubs.values():
+            try:
+                lst.remove(retracted_pub)
+            except ValueError:
+                pass
         return None


### PR DESCRIPTION
The registry can now generate retraction nanopubs, accounts can have multiple pubkeys. Generator now tracks active accounts and adds/removes accounts with a defined frequency.