### PR TITLE
Add logging persistence and hard resource limits

### DIFF
--- a/get-logs.sh
+++ b/get-logs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+replicas=$1
+
+ts=$(date +%s)
+logfile="/tmp/nanopub-log-$ts"
+logfiledb="$logfile-registry-db"
+logfilequery="$logfile-query"
+logfileregistry="$logfile-registry-application"
+
+for i in $(seq 1 $replicas); do
+    logfiledb_now="$logfiledb-$i.log"
+    kubectl logs -f "nanopub-$i-registry-db-0" > $logfiledb_now 2>&1 &
+    pid=$!
+    echo "kubectl logs running as PID $pid"
+    logfilequery_now="$logfilequery-$i.log"
+    kubectl logs -f "nanopub-$i-query-application-0" > $logfilequery_now 2>&1 &
+    pid=$!
+    echo "kubectl logs running as PID $pid"
+    logfileregistry_now="$logfileregistry-$i.log"
+    kubectl logs -f "nanopub-$i-registry-application-0" > $logfileregistry_now 2>&1 &
+    pid=$!
+    echo "kubectl logs running as PID $pid"
+done

--- a/get-logs.sh
+++ b/get-logs.sh
@@ -6,19 +6,32 @@ ts=$(date +%s)
 logfile="/tmp/nanopub-log-$ts"
 logfiledb="$logfile-registry-db"
 logfilequery="$logfile-query"
+logfilerdf4j="$logfile-rdf4j"
 logfileregistry="$logfile-registry-application"
+pidfile="$logfile-pid"
 
 for i in $(seq 1 $replicas); do
     logfiledb_now="$logfiledb-$i.log"
-    kubectl logs -f "nanopub-$i-registry-db-0" > $logfiledb_now 2>&1 &
+    nohup kubectl logs -f "nanopub-$i-registry-db-0" > $logfiledb_now 2>&1 < /dev/null &
     pid=$!
+    echo "$pid" >> "$pidfile"
     echo "kubectl logs running as PID $pid"
     logfilequery_now="$logfilequery-$i.log"
-    kubectl logs -f "nanopub-$i-query-application-0" > $logfilequery_now 2>&1 &
+    nohup kubectl logs -f "nanopub-$i-query-application-0" > $logfilequery_now 2>&1 < /dev/null &
     pid=$!
     echo "kubectl logs running as PID $pid"
+    echo "$pid" >> "$pidfile"
+    logfilerdf4j_now="$logfilerdf4j-$i.log"
+    nohup kubectl logs -f "nanopub-$i-query-rdf4j-0" > $logfilerdf4j_now 2>&1 < /dev/null &
+    pid=$!
+    echo "kubectl logs running as PID $pid"
+    echo "$pid" >> "$pidfile"
     logfileregistry_now="$logfileregistry-$i.log"
-    kubectl logs -f "nanopub-$i-registry-application-0" > $logfileregistry_now 2>&1 &
+    nohup kubectl logs -f "nanopub-$i-registry-application-0" > $logfileregistry_now 2>&1 < /dev/null &
     pid=$!
     echo "kubectl logs running as PID $pid"
+    echo "$pid" >> "$pidfile"
 done
+
+# then run xargs -r kill < "$pidfile"
+# to kill processes 

--- a/helm-chart/charts/query/templates/application/statefulset.yaml
+++ b/helm-chart/charts/query/templates/application/statefulset.yaml
@@ -59,6 +59,16 @@ spec:
               value: "http://{{ include "rdf4j.fullname" .}}:8080/rdf4j-server/"
             - name: REGISTRY_FIXED_URL
               value: "http://{{ .Release.Name }}-registry-application:9292/"
+            - name: NANOPUB_QUERY_ENABLE_TRUST_STATE
+              value: "false"
+            - name: NANOPUB_QUERY_ENABLE_SPACES
+              value: "false"
+            - name: NANOPUB_QUERY_ENABLE_FULL_REPO
+              value: "false"
+            - name: NANOPUB_QUERY_ENABLE_TEXT_REPO
+              value: "false"
+            - name: NANOPUB_QUERY_ENABLE_LAST30D_REPO
+              value: "false"
           volumeMounts:
             - name: '{{ include "application.fullname" . }}-data'
               mountPath: {{.Values.application.persistence.mountPath | quote }}

--- a/helm-chart/charts/query/templates/rdf4j/statefulset.yaml
+++ b/helm-chart/charts/query/templates/rdf4j/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
               mountPath: {{ .Values.rdf4j.persistence.mountPath | quote }}
           env:
             - name: JAVA_OPTS
-            - value: {{ .Values.rdf4j.javaOpts}}
+              value: {{ .Values.rdf4j.javaOpts }}
           {{- with .Values.rdf4j.envVars }}
           {{- end }}
   volumeClaimTemplates:

--- a/helm-chart/charts/query/templates/rdf4j/statefulset.yaml
+++ b/helm-chart/charts/query/templates/rdf4j/statefulset.yaml
@@ -54,6 +54,10 @@ spec:
               mountPath: {{ .Values.rdf4j.persistenceLogs.mountPath | quote }}
             - name: "data-{{include "rdf4j.fullname" .}}"
               mountPath: {{ .Values.rdf4j.persistence.mountPath | quote }}
+            - name: rdf4j-logback
+              mountPath: /var/rdf4j/Server/conf/logback.xml
+              subPath: logback.xml
+              readOnly: true
           env:
             - name: JAVA_OPTS
               value: {{ .Values.rdf4j.javaOpts }}
@@ -90,3 +94,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.rdf4j.persistenceLogs.size | quote }}
+  volumes: 
+    - name: rdf4j-logback
+      configMap:
+        name: rdf4j-logback

--- a/helm-chart/charts/query/templates/rdf4j/statefulset.yaml
+++ b/helm-chart/charts/query/templates/rdf4j/statefulset.yaml
@@ -54,10 +54,6 @@ spec:
               mountPath: {{ .Values.rdf4j.persistenceLogs.mountPath | quote }}
             - name: "data-{{include "rdf4j.fullname" .}}"
               mountPath: {{ .Values.rdf4j.persistence.mountPath | quote }}
-            - name: rdf4j-logback
-              mountPath: /var/rdf4j/Server/conf/logback.xml
-              subPath: logback.xml
-              readOnly: true
           env:
             - name: JAVA_OPTS
               value: {{ .Values.rdf4j.javaOpts }}
@@ -94,7 +90,3 @@ spec:
         resources:
           requests:
             storage: {{ .Values.rdf4j.persistenceLogs.size | quote }}
-  volumes: 
-    - name: rdf4j-logback
-      configMap:
-        name: rdf4j-logback

--- a/helm-chart/charts/query/values.yaml
+++ b/helm-chart/charts/query/values.yaml
@@ -8,7 +8,7 @@ application:
   image:
     repository: nanopub/query
     pullPolicy: Always
-    tag: "1.8.0"
+    tag: "1.9.0"
     # Overrides the image tag whose default is the chart appVersion.
 
   replicaCount: 1

--- a/helm-chart/charts/query/values.yaml
+++ b/helm-chart/charts/query/values.yaml
@@ -82,7 +82,7 @@ rdf4j:
     repository: nanopub/rdf4j-workbench
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "5.1.3-SNAPSHOT"
+    tag: "latest"
 
   replicaCount: 1
   service:

--- a/helm-chart/charts/query/values.yaml
+++ b/helm-chart/charts/query/values.yaml
@@ -95,9 +95,9 @@ rdf4j:
 
   resources: 
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
-      memory: 4Gi
+      memory: 8Gi
 
   autoscaling:
     enabled: false

--- a/helm-chart/charts/query/values.yaml
+++ b/helm-chart/charts/query/values.yaml
@@ -8,7 +8,7 @@ application:
   image:
     repository: nanopub/query
     pullPolicy: Always
-    tag: "1.9.0"
+    tag: "1.10.0"
     # Overrides the image tag whose default is the chart appVersion.
 
   replicaCount: 1

--- a/helm-chart/charts/query/values.yaml
+++ b/helm-chart/charts/query/values.yaml
@@ -8,7 +8,7 @@ application:
   image:
     repository: nanopub/query
     pullPolicy: Always
-    tag: "latest"
+    tag: "1.8.0"
     # Overrides the image tag whose default is the chart appVersion.
 
   replicaCount: 1
@@ -82,7 +82,7 @@ rdf4j:
     repository: nanopub/rdf4j-workbench
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "latest"
+    tag: "5.2.2-SNAPSHOT-b"
 
   replicaCount: 1
   service:

--- a/helm-chart/charts/query/values.yaml
+++ b/helm-chart/charts/query/values.yaml
@@ -79,7 +79,7 @@ rdf4j:
   tier: internal
   javaOpts: "-Dorg.eclipse.rdf4j.client.http.connectionTimeout=10000 -Dorg.eclipse.rdf4j.client.http.connectionRequestTimeout=10000 -Dorg.eclipse.rdf4j.client.http.socketTimeout=10000"
   image:
-    repository: nanopub/rdf4j-workbench
+    repository: ostrzyciel/rdf4j-workbench-tomcat
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: "5.2.2-SNAPSHOT-b"
@@ -93,13 +93,11 @@ rdf4j:
     containerPort: 8080
     protocol: TCP
 
-  resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  resources: 
+    limits:
+      memory: 4Gi
+    requests:
+      memory: 4Gi
 
   autoscaling:
     enabled: false

--- a/helm-chart/charts/registry/templates/application/statefulset.yaml
+++ b/helm-chart/charts/registry/templates/application/statefulset.yaml
@@ -54,11 +54,13 @@ spec:
             - name: REGISTRY_DB_HOST
               value: {{ include "db.fullname" . }}
             - name: REGISTRY_TEST_INSTANCE
-              value: "true"
+              value: "false"
             - name: REGISTRY_SERVICE_URL
               value: "http://{{ include "application.fullname" . }}:{{ .Values.application.service.port }}"
             - name: REGISTRY_PEER_URLS
               value: {{ .Values.application.registryPeerUrls | quote }}
+            - name: REGISTRY_PRIORITIZE_ALL_PUBKEYS
+              value: "true"
           volumeMounts:
             - name: setting-trig
               mountPath: /data

--- a/helm-chart/charts/registry/templates/db/statefulset.yaml
+++ b/helm-chart/charts/registry/templates/db/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
             - containerPort: {{ .Values.db.service.containerPort }}
               protocol: {{ .Values.db.service.protocol }}
           command: ["/bin/bash"]
-          args: ["-c", 'echo "rs.initiate()" > /docker-entrypoint-initdb.d/1-init-replicaset.js && /usr/local/bin/docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --noauth']
+          args: ["-c", 'echo "rs.initiate()" > /docker-entrypoint-initdb.d/1-init-replicaset.js && /usr/local/bin/docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --noauth --wiredTigerCacheSizeGB=1.5']
           volumeMounts:
             - name: "{{ include "db.fullname" . }}-data"
               mountPath: {{.Values.db.persistence.mountPath | quote }}

--- a/helm-chart/charts/registry/values.yaml
+++ b/helm-chart/charts/registry/values.yaml
@@ -15,7 +15,7 @@ application:
   image:
     repository: nanopub/registry
     pullPolicy: Always
-    tag: "1.8.1"
+    tag: "1.9.0"
     # Overrides the image tag whose default is the chart appVersion.
 
   replicaCount: 1

--- a/helm-chart/charts/registry/values.yaml
+++ b/helm-chart/charts/registry/values.yaml
@@ -15,12 +15,12 @@ application:
   image:
     repository: nanopub/registry
     pullPolicy: Always
-    tag: "latest"
+    tag: "1.8.0"
     # Overrides the image tag whose default is the chart appVersion.
 
   replicaCount: 1
 
-  registryPeerUrls: ""
+  registryPeerUrls: "https://registry.petapico.org/ https://registry.knowledgepixels.com/"
 
   service:
     type: NodePort

--- a/helm-chart/charts/registry/values.yaml
+++ b/helm-chart/charts/registry/values.yaml
@@ -88,9 +88,9 @@ db:
 
   resources: 
     limits:
-      memory: 4Gi
+      memory: 8Gi
     requests:
-      memory: 4Gi
+      memory: 8Gi
 
   autoscaling:
     enabled: false

--- a/helm-chart/charts/registry/values.yaml
+++ b/helm-chart/charts/registry/values.yaml
@@ -15,7 +15,7 @@ application:
   image:
     repository: nanopub/registry
     pullPolicy: Always
-    tag: "1.8.0"
+    tag: "1.8.1"
     # Overrides the image tag whose default is the chart appVersion.
 
   replicaCount: 1
@@ -86,13 +86,11 @@ db:
     containerPort: 27017
     protocol: TCP
 
-  resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  resources: 
+    limits:
+      memory: 4Gi
+    requests:
+      memory: 4Gi
 
   autoscaling:
     enabled: false

--- a/multi-node-setup.sh
+++ b/multi-node-setup.sh
@@ -57,7 +57,7 @@ joined=""
 for i in $(seq 1 $replicas); do
     joined+="http://nanopub-$i-registry-application:9292/"
     if [ $i -lt $replicas ]; then
-        joined+=";"
+        joined+=" "
     fi
 done
 


### PR DESCRIPTION
The PR adds a scripts that allows for additional backups of nanopub logs, as well as some additional environmental variables and hard resource limits for RDF4J and MongoDB instances.