### PR TITLE
Add changes to generators for speed and configurations

### DIFF
--- a/nanopub_generator/config.yaml
+++ b/nanopub_generator/config.yaml
@@ -1,6 +1,6 @@
 generator:
   # Interval in milliseconds between posts
-  post_interval: 2000
+  post_interval: 0
   # Random seed for reproducibility
   seed: 42
 
@@ -26,8 +26,7 @@ query:
   # Probability of choosing a specific repository for a query
   # Otherwise, a random pubkey or type repository is chosen
   probabilities_endpoints:
-    full: 0.1
-    last30d: 0.1
+    {}
 
   # Queries to run against the repository
   # The weights are relative and determine query frequency in the query mix.

--- a/nanopub_generator/config.yaml
+++ b/nanopub_generator/config.yaml
@@ -6,7 +6,7 @@ generator:
 
   users:
     # Number of users to generate
-    count: 10
+    count: 50
 
 query:
   # Random sample for sampling reproducibility
@@ -21,12 +21,15 @@ query:
 
   users:
     # Number of users making requests in parallel
-    count: 10
+    count: 8
 
   # Probability of choosing a specific repository for a query
   # Otherwise, a random pubkey or type repository is chosen
   probabilities_endpoints:
-    {}
+    full: 0.1
+    last30d: 0.1
+    # For reproducing experiments for the paper, use:
+    # {}
 
   # Queries to run against the repository
   # The weights are relative and determine query frequency in the query mix.

--- a/nanopub_generator/nanopub_generator/data_gen.py
+++ b/nanopub_generator/nanopub_generator/data_gen.py
@@ -2,6 +2,9 @@ from faker import Faker
 import nanopub as np
 from random import Random
 import rdflib as rdf
+from rdflib.namespace import XSD
+
+from datetime import datetime, timedelta
 
 from distribution import ParetoDistList, ParetoDist
 from recent_nanopubs import RecentNanopubs
@@ -87,11 +90,24 @@ class NanopubFaker(Faker):
             NPX.hasNanopubType,
             np_type
         ))
-        return np.Nanopub(
+        nanopub =  np.Nanopub(
             conf=conf,
             assertion=assertion,
             pubinfo=p,
         )
+        # generate timestamps here for more precise control
+        timestamp = datetime.now()-timedelta(hours=1)
+        nanopub.pubinfo.add((
+            rdf.URIRef("http://purl.org/nanopub/temp/np#"),
+            rdf.URIRef("http://www.w3.org/ns/prov#generatedAtTime"),
+            rdf.Literal(timestamp, datatype=XSD.dateTime)
+        ))
+        nanopub.provenance.add((
+            rdf.URIRef("http://purl.org/nanopub/temp/np#assertion"),
+            rdf.URIRef("http://www.w3.org/ns/prov#generatedAtTime"),
+            rdf.Literal(timestamp, datatype=XSD.dateTime)
+        ))
+        return nanopub
 
     def add_blank_node(self, g: rdf.Graph) -> rdf.BNode:
         """Add a blank node with some extra information to the graph."""

--- a/nanopub_generator/nanopub_generator/data_gen.py
+++ b/nanopub_generator/nanopub_generator/data_gen.py
@@ -96,7 +96,7 @@ class NanopubFaker(Faker):
             pubinfo=p,
         )
         # generate timestamps here for more precise control
-        timestamp = datetime.now()-timedelta(hours=1)
+        timestamp = datetime.now()-timedelta(hours=2)
         nanopub.pubinfo.add((
             rdf.URIRef("http://purl.org/nanopub/temp/np#"),
             rdf.URIRef("http://www.w3.org/ns/prov#generatedAtTime"),

--- a/nanopub_generator/nanopub_generator/generator.py
+++ b/nanopub_generator/nanopub_generator/generator.py
@@ -26,8 +26,8 @@ class NanopubGenerator:
                     NanopubConf(
                         use_server=self.registry_url,
                         profile=profile,
-                        add_prov_generated_time=True,
-                        add_pubinfo_generated_time=True,
+                        add_prov_generated_time=False,
+                        add_pubinfo_generated_time=False,
                         attribute_publication_to_profile=True,
                         attribute_assertion_to_profile=True,
                     )
@@ -80,8 +80,8 @@ class NanopubGenerator:
                         account_orcid,
                         self.np_accounts_map[account_orcid][0].profile.name,
                     ),
-                    add_prov_generated_time=True,
-                    add_pubinfo_generated_time=True,
+                    add_prov_generated_time=False,
+                    add_pubinfo_generated_time=False,
                     attribute_publication_to_profile=True,
                     attribute_assertion_to_profile=True,
                 )
@@ -109,8 +109,8 @@ class NanopubGenerator:
                 NanopubConf(
                     use_server=self.registry_url,
                     profile=profile,
-                    add_prov_generated_time=True,
-                    add_pubinfo_generated_time=True,
+                    add_prov_generated_time=False,
+                    add_pubinfo_generated_time=False,
                     attribute_publication_to_profile=True,
                     attribute_assertion_to_profile=True,
                 )

--- a/nanopub_generator/nanopub_generator/main.py
+++ b/nanopub_generator/nanopub_generator/main.py
@@ -36,6 +36,12 @@ parser.add_argument(
     type=str,
     help="Mode for generator pipeline. Possible values: registry, query. Required.",
 )
+
+parser.add_argument(
+    "--check-test-instance",
+    action="store_false",
+    help="If set, checks that specified registry instance is in the test mode. ",
+)
 parser.add_argument(
     "--verbose",
     action="store_true",
@@ -98,12 +104,12 @@ def run_registry(args: Namespace, config: dict):
         if not args.registry_url:
             print("Error: --registry-url is required when not in dry-run mode.")
             return 1
-        # try:
-        #     verify_test_instance(args.registry_url)
-        # except Exception as e:
-        #     print(f"Error verifying registry URL: {e}")
-        #     return 1
-
+        if args.check_test_instance:
+            try:
+                verify_test_instance(args.registry_url)
+            except Exception as e:
+                print(f"Error verifying registry URL: {e}")
+                return 1
     generator = NanopubGenerator(config, args)
     # Schedule the nanopub publishing task
     if config["generator"]["post_interval"] > 0:

--- a/nanopub_generator/nanopub_generator/main.py
+++ b/nanopub_generator/nanopub_generator/main.py
@@ -106,15 +106,19 @@ def run_registry(args: Namespace, config: dict):
 
     generator = NanopubGenerator(config, args)
     # Schedule the nanopub publishing task
-    schedule.every(config["generator"]["post_interval"] / 1000).seconds.do(
-        generator.publish_nanopub_safe,
-    )
+    if config["generator"]["post_interval"] > 0:
+        schedule.every(config["generator"]["post_interval"] / 1000).seconds.do(
+            generator.publish_nanopub_safe,
+        )
+        nanopub_publish_func = schedule.run_pending
+    # or proceed as is for faster publishing if post_interval = 0
+    else:
+        nanopub_publish_func = generator.publish_nanopub_safe
 
     print("Nanopub generator started. Press Ctrl+C to stop.")
     start_time = time.time()
     while True:
-        schedule.run_pending()
-        time.sleep(1)
+        nanopub_publish_func()
         if args.end_after_seconds and (time.time() - start_time) >= args.end_after_seconds:
             print(f"Ending generator after {args.end_after_seconds} seconds as requested.")
             break

--- a/nanopub_generator/nanopub_generator/main.py
+++ b/nanopub_generator/nanopub_generator/main.py
@@ -98,11 +98,11 @@ def run_registry(args: Namespace, config: dict):
         if not args.registry_url:
             print("Error: --registry-url is required when not in dry-run mode.")
             return 1
-        try:
-            verify_test_instance(args.registry_url)
-        except Exception as e:
-            print(f"Error verifying registry URL: {e}")
-            return 1
+        # try:
+        #     verify_test_instance(args.registry_url)
+        # except Exception as e:
+        #     print(f"Error verifying registry URL: {e}")
+        #     return 1
 
     generator = NanopubGenerator(config, args)
     # Schedule the nanopub publishing task


### PR DESCRIPTION
Summary of changes:
1) remove post interval and sleep for the generator
2) add a command line arg for disabling registry test instance check (by default is ON)
3) add timestamp - 2h logic to mitigate issue with error 400, now `generatedAtTime` is manually produced
4) set the number of users in query/generator as in the experiments
5) preserve original `probabilities_endpoints`, and added note on what was used for experiments